### PR TITLE
Port to python3

### DIFF
--- a/plugins/alleycat/alleycat.py
+++ b/plugins/alleycat/alleycat.py
@@ -19,11 +19,11 @@ def add_to_namespace(namespace, source, name, variable):
     '''
     Add a variable to a different namespace, likely __main__.
     '''
+    import importlib
     importer_module = sys.modules[namespace]
-    if source in sys.modules.keys():
-        reload(sys.modules[source])
+    if source in list(sys.modules.keys()):
+        importlib.reload(sys.modules[source])
     else:
-        import importlib
         m = importlib.import_module(source, None)
         sys.modules[source] = m
 
@@ -56,8 +56,8 @@ class AlleyCat(object):
         # We work backwards via xrefs, so we start at the end and end at the
         # start
         if not self.quiet:
-            print "Generating call paths from %s to %s..." % (self._name(end),
-                                                              self._name(start))
+            print("Generating call paths from %s to %s..." % (self._name(end),
+                                                              self._name(start)))
         self._build_paths(start, end)
 
     def _name(self, ea):
@@ -442,7 +442,7 @@ class AlleyCatGraph(idaapi.GraphViewer):
         xref_locations = []
         node_ea = self.get_ea_by_name(self[node_id])
 
-        if self.edges.has_key(node_id):
+        if node_id in self.edges:
             for edge_node_id in self.edges[node_id]:
 
                 edge_node_name = self[edge_node_id]
@@ -457,14 +457,14 @@ class AlleyCatGraph(idaapi.GraphViewer):
         if xref_locations:
             xref_locations.sort()
 
-            print ""
-            print "Path Xrefs from %s:" % self[node_id]
-            print "-" * 100
+            print("")
+            print("Path Xrefs from %s:" % self[node_id])
+            print("-" * 100)
             for (xref_ea, dst_ea) in xref_locations:
-                print "%-50s  =>  %s" % (self.get_name_by_ea(xref_ea),
-                                         self.get_name_by_ea(dst_ea))
-            print "-" * 100
-            print ""
+                print("%-50s  =>  %s" % (self.get_name_by_ea(xref_ea),
+                                         self.get_name_by_ea(dst_ea)))
+            print("-" * 100)
+            print("")
 
             ida_shims.jumpto(xref_locations[0][0])
         else:
@@ -571,7 +571,7 @@ class AlleyCatPaths(object):
                 s = time.time()
                 r = klass(source, target).paths
                 e = time.time()
-                print "Found %d paths in %f seconds." % (len(r), (e-s))
+                print("Found %d paths in %f seconds." % (len(r), (e-s)))
 
                 if r:
                     results += r
@@ -579,7 +579,7 @@ class AlleyCatPaths(object):
                     name = ida_shims.get_name(target)
                     if not name:
                         name = "0x%X" % target
-                    print "No paths found to", name
+                    print("No paths found to", name)
 
         if results:
             # Be sure to close any previous graph before creating a new one.

--- a/plugins/alleycat/alleycat.py
+++ b/plugins/alleycat/alleycat.py
@@ -168,7 +168,7 @@ class AlleyCatCodePaths(AlleyCat):
                                     end_ea)
 
         start_func_ea = ida_shims.start_ea(start_func)
-        end_func_ea = ida_shims.end_ea(end_func)
+        end_func_ea = ida_shims.start_ea(end_func)
 
         if start_func_ea != end_func_ea:
             raise AlleyCatException("The start and end addresses are not part "

--- a/plugins/alleycat/alleycat.py
+++ b/plugins/alleycat/alleycat.py
@@ -20,9 +20,14 @@ def add_to_namespace(namespace, source, name, variable):
     Add a variable to a different namespace, likely __main__.
     '''
     import importlib
+
     importer_module = sys.modules[namespace]
     if source in list(sys.modules.keys()):
-        importlib.reload(sys.modules[source])
+        if not (sys.version_info.major == 3 and sys.version_info.minor >= 4):
+            import imp
+            imp.reload(sys.modules[source])
+        else:
+            importlib.reload(sys.modules[source])
     else:
         m = importlib.import_module(source, None)
         sys.modules[source] = m

--- a/plugins/codatify/codatify.py
+++ b/plugins/codatify/codatify.py
@@ -66,7 +66,7 @@ class StructPatternDetector(object):
                 struct2 = StructCast(address, n)
                 this_pattern = [x.type for x in struct2.entries[p1:p2+1]]
                 if this_pattern == pattern_to_match:
-                    entry_element_count = (address - ea) / self.element_size
+                    entry_element_count = int((address - ea) / self.element_size)
                     break
 
             if entry_element_count is not None and entry_element_count > 0:
@@ -120,7 +120,7 @@ class StructPatternDetector(object):
 class Struct(object):
 
     def __init__(self, **kwargs):
-        for (k, v) in kwargs.iteritems():
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
@@ -159,8 +159,8 @@ class StructFinder(object):
     def search(self):
         patterns = []
 
-        print "Searching for data structure arrays from %s to %s" % \
-              (hex(self.start), hex(self.stop))
+        print("Searching for data structure arrays from %s to %s" % \
+              (hex(self.start), hex(self.stop)))
 
         ea = self.start
         while ea < self.stop:
@@ -186,14 +186,14 @@ class StructFinder(object):
                 else:
                     j += 1
 
-            print "Found an array of %d structures at 0x%X - 0x%X. Each " \
+            print("Found an array of %d structures at 0x%X - 0x%X. Each " \
                   "entry has %d elements of %d bytes each." % \
                   (patterns[i].num_entries, patterns[i].start, patterns[i].stop,
-                   patterns[i].num_elements, patterns[i].element_size)
+                   patterns[i].num_elements, patterns[i].element_size))
 
-            print "Array element #%d is the address pointer, and element #%d " \
+            print("Array element #%d is the address pointer, and element #%d " \
                   "is the address pointer name.\n" % \
-                  (patterns[i].function_element, patterns[i].name_element)
+                  (patterns[i].function_element, patterns[i].name_element))
 
             i += 1
 
@@ -213,16 +213,16 @@ class StructFinder(object):
                     ea + (pattern.function_element * pattern.element_size))
 
                 new_function_name = ida_shims.get_strlit_contents(
-                    string_address)
+                    string_address).decode("utf8")
                 current_function_name = ida_shims.get_name(function_address)
 
                 if not self.valid_function_name(new_function_name):
-                    print "ERROR: '%s' is not a valid function name. This is " \
+                    print("ERROR: '%s' is not a valid function name. This is " \
                           "likely not a function table, or I have parsed it " \
-                          "incorrectly!" % new_function_name
-                    print "       Ignoring all entries in the structures " \
+                          "incorrectly!" % new_function_name)
+                    print("       Ignoring all entries in the structures " \
                           "between 0x%X and 0x%X.\n" % (pattern.start,
-                                                        pattern.stop)
+                                                        pattern.stop))
                     name2func = {}
                     break
                 elif current_function_name.startswith("sub_"):
@@ -230,12 +230,12 @@ class StructFinder(object):
 
                 ea += (pattern.num_elements * pattern.element_size)
 
-            for (name, address) in name2func.iteritems():
-                print "0x%.8X => %s" % (address, name)
+            for (name, address) in name2func.items():
+                print("0x%.8X => %s" % (address, name))
                 ida_shims.set_name(address, name)
                 count += 1
 
-        print "Renamed %d functions!" % count
+        print("Renamed %d functions!" % count)
 
 
 class FunctionNameology(object):
@@ -254,16 +254,16 @@ class FunctionNameology(object):
         '''
         count = 0
 
-        for (function_address, function_name) in self.func2str_mappings().iteritems():
+        for (function_address, function_name) in self.func2str_mappings().items():
             if ida_shims.get_name(function_address).startswith("sub_"):
                 if dry_run or ida_shims.set_name(function_address, function_name):
                     if debug:
-                        print "0x%.8X  =>  %s" % (function_address,
-                                                  function_name)
+                        print("0x%.8X  =>  %s" % (function_address,
+                                                  function_name))
                     count += 1
 
         if debug:
-            print "Renamed %d functions based on unique string xrefs!" % count
+            print("Renamed %d functions based on unique string xrefs!" % count)
 
         return count
 
@@ -280,12 +280,12 @@ class FunctionNameology(object):
             if self.is_valid_function_name(str(string)):
                 function_address = self.str2func(string.ea)
                 if function_address is not None:
-                    if not function_map.has_key(function_address):
+                    if function_address not in function_map:
                         function_map[function_address] = []
                     function_map[function_address].append(str(string))
 
         # Each function must have only one candidate string
-        for function_address in function_map.keys():
+        for function_address in list(function_map.keys()):
             if len(function_map[function_address]) == 1:
                 function_map[function_address] = function_map[function_address][0]
             else:
@@ -363,7 +363,7 @@ class Codatify(object):
         if ea == idc.BADADDR:
             ea = ida_shims.get_first_seg()
 
-        print "Looking for possible strings starting at: 0x%X..." % ea,
+        print("Looking for possible strings starting at: 0x%X..." % ea, end=' ')
 
         for s in idautils.Strings():
             if s.ea > ea:
@@ -371,7 +371,7 @@ class Codatify(object):
                         and ida_shims.create_strlit(s.ea, 0):
                     n += 1
 
-        print "created %d new ASCII strings" % n
+        print("created %d new ASCII strings" % n)
 
     # Converts remaining data into DWORDS.
     def datify(self):
@@ -379,7 +379,7 @@ class Codatify(object):
         if ea == idc.BADADDR:
             ea = ida_shims.get_first_seg()
 
-        print "Converting remaining data to DWORDs...",
+        print("Converting remaining data to DWORDs...", end=' ')
 
         while ea != idc.BADADDR:
             flags = ida_shims.get_full_flags(ea)
@@ -391,14 +391,14 @@ class Codatify(object):
 
             ea = ida_shims.next_addr(ea)
 
-        print "done."
+        print("done.")
 
         self._fix_data_offsets()
 
     def pointify(self):
         counter = 0
 
-        print "Renaming pointers...",
+        print("Renaming pointers...", end=' ')
 
         for (name_ea, name) in idautils.Names():
             for xref in idautils.XrefsTo(name_ea):
@@ -415,13 +415,13 @@ class Codatify(object):
                     #else:
                     #    print "Failed to create name '%s'!" % new_name
 
-        print "renamed %d pointers" % counter
+        print("renamed %d pointers" % counter)
 
     def _fix_data_offsets(self):
         ea = 0
         count = 0
 
-        print "Fixing unresolved offset xrefs...",
+        print("Fixing unresolved offset xrefs...", end=' ')
 
         while ea != idaapi.BADADDR:
             (ea, n) = idaapi.find_notype(ea, idaapi.SEARCH_DOWN)
@@ -435,7 +435,7 @@ class Codatify(object):
                                         (idaapi.dr_O | idaapi.XREF_USER))
                         count += 1
 
-        print "created %d new data xrefs" % count
+        print("created %d new data xrefs" % count)
 
     # Creates functions and code blocks
     def codeify(self, ea=idc.BADADDR):
@@ -447,8 +447,8 @@ class Codatify(object):
             if ea == idc.BADADDR:
                 ea = ida_shims.get_first_seg()
 
-        print "\nLooking for undefined code starting at: %s:0x%X" % \
-              (ida_shims.get_segm_name(ea), ea)
+        print("\nLooking for undefined code starting at: %s:0x%X" % \
+              (ida_shims.get_segm_name(ea), ea))
 
         while ea != idc.BADADDR:
             try:
@@ -466,8 +466,8 @@ class Codatify(object):
 
             ea = ida_shims.next_addr(ea)
 
-        print "Created %d new functions and %d new code blocks\n" % \
-              (func_count, code_count)
+        print("Created %d new functions and %d new code blocks\n" % \
+              (func_count, code_count))
 
 
 try:

--- a/plugins/codatify/codatify.py
+++ b/plugins/codatify/codatify.py
@@ -6,6 +6,7 @@
 # Craig Heffner
 # Tactical Network Solutions
 
+from __future__ import print_function
 import idc
 import string
 import idaapi

--- a/plugins/funcprofiler/funcprofiler.py
+++ b/plugins/funcprofiler/funcprofiler.py
@@ -17,7 +17,7 @@ IDA_FUNCTION_PROFILES = None
 
 class IDAProfilerXref(object):
     def __init__(self, **kwargs):
-        for (k, v) in kwargs.iteritems():
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
@@ -36,7 +36,7 @@ class IDAFunctionProfiler(object):
                 func = idaapi.get_func(xref.frm)
                 if func:
                     start_ea = ida_shims.start_ea(func)
-                    if not self.functions.has_key(start_ea):
+                    if start_ea not in self.functions:
                         self.functions[start_ea] = list()
 
                     xref = IDAProfilerXref(ea=string.ea, string=key_string,
@@ -49,7 +49,7 @@ class IDAFunctionProfiler(object):
                 func = idaapi.get_func(xref.frm)
                 if func:
                     start_ea = ida_shims.start_ea(func)
-                    if not self.functions.has_key(start_ea):
+                    if start_ea not in self.functions:
                         self.functions[start_ea] = list()
 
                     self.functions[start_ea].append(IDAProfilerXref(
@@ -57,7 +57,7 @@ class IDAFunctionProfiler(object):
                         xref=xref.frm, type=callable))
 
     def _sort_functions(self):
-        for function in self.functions.keys():
+        for function in list(self.functions.keys()):
             self.functions[function] = sorted(self.functions[function],
                                               key=attrgetter('xref'))
 
@@ -124,7 +124,7 @@ class IDAFunctionProfilerChooser(choose):
     def populate_items(self):
         self.items = []
 
-        for (func_ea, xrefs) in self.profile.functions.iteritems():
+        for (func_ea, xrefs) in self.profile.functions.items():
             if not self.function_filters or func_ea in self.function_filters:
                 orig_items_len = len(self.items)
 
@@ -184,12 +184,12 @@ class IDAFunctionProfilerChooser(choose):
 
         if regex_str:
             if dryrun:
-                print "Testing regex rename rule: '%s'" % regex_str
+                print("Testing regex rename rule: '%s'" % regex_str)
 
             regex = re.compile(regex_str)
 
             # Look at all the profiled functions
-            for (function, xrefs) in self.profile.functions.iteritems():
+            for (function, xrefs) in self.profile.functions.items():
                 new_function_name = ""
 
                 # Don't rename functions that have already been renamed
@@ -225,14 +225,14 @@ class IDAFunctionProfilerChooser(choose):
                         n += 1
 
                     if dryrun:
-                        print "%s => %s" % (idc.Name(function),
-                                            new_function_name)
+                        print("%s => %s" % (idc.Name(function),
+                                            new_function_name))
                         count += 1
                     else:
                         if ida_shims.set_name(function, new_function_name):
                             count += 1
 
-            print "Renamed %d functions" % count
+            print("Renamed %d functions" % count)
 
 
 def from_function_profiler(arg=None):
@@ -248,7 +248,7 @@ def from_function_profiler(arg=None):
                             "because 0x%X is not inside a function!" % cur_loc)
         chooser.show()
     except Exception as e:
-        print "IDAFunctionProfiler ERROR: %s" % str(e)
+        print("IDAFunctionProfiler ERROR: %s" % str(e))
 
 
 def all_functions_profiler(arg=None):
@@ -256,7 +256,7 @@ def all_functions_profiler(arg=None):
         chooser = IDAFunctionProfilerChooser()
         chooser.show()
      except Exception as e:
-        print "IDAFunctionProfiler ERROR: %s" % str(e)
+        print("IDAFunctionProfiler ERROR: %s" % str(e))
 
 
 try:

--- a/plugins/leafblower/leafblower.py
+++ b/plugins/leafblower/leafblower.py
@@ -130,7 +130,7 @@ class LeafBlowerFunctionChooser(choose):
 
 class ArchitectureSettings(object):
     def __init__(self, **kwargs):
-        for (k, v) in kwargs.iteritems():
+        for (k, v) in kwargs.items():
             setattr(self, k, v)
 
 
@@ -226,7 +226,7 @@ class Function(object):
         self.candidates = {}
         self.argp = ArgParser()
 
-        for (k,v) in kwargs.iteritems():
+        for (k,v) in kwargs.items():
             setattr(self, k, v)
 
         self.name = ida_shims.get_name(self.start)

--- a/plugins/leafblower/leafblower.py
+++ b/plugins/leafblower/leafblower.py
@@ -54,6 +54,9 @@ class LeafBlowerFunctionChooser(choose):
     def OnClose(self):
         pass
 
+    def AddCommand(self, caption):
+        pass
+
     def OnCommand(self, n, cmd):
         if cmd == self.show_all_toggle_cmd:
 
@@ -122,10 +125,8 @@ class LeafBlowerFunctionChooser(choose):
     def show(self):
         if self.Show(modal=False) < 0:
             return False
-        self.show_all_toggle_cmd = self.AddCommand(
-            "Toggle 'show all leaf functions'")
-        self.rename_cmd = self.AddCommand(
-            "Rename all sub_XXXXXX leaf functions to 'leaf_XXXXXX'")
+        self.show_all_toggle_cmd = self.AddCommand("Toggle 'show all leaf functions'")
+        self.rename_cmd = self.AddCommand("Rename all sub_XXXXXX leaf functions to 'leaf_XXXXXX'")
 
 
 class ArchitectureSettings(object):

--- a/plugins/localxrefs/localxrefs.py
+++ b/plugins/localxrefs/localxrefs.py
@@ -27,9 +27,14 @@ def add_to_namespace(namespace, name, variable):
     Add a variable to a different namespace, likely __main__.
     '''
     import importlib
+
     importer_module = sys.modules[namespace]
     if name in sys.modules.keys():
-        importlib.reload(sys.modules[name])
+        if not (sys.version_info.major == 3 and sys.version_info.minor >= 4):
+            import imp
+            imp.reload(sys.modules[name])
+        else:
+            importlib.reload(sys.modules[name])
     else:
         m = importlib.import_module(name, None)
         sys.modules[name] = m

--- a/plugins/localxrefs/localxrefs.py
+++ b/plugins/localxrefs/localxrefs.py
@@ -26,11 +26,11 @@ def add_to_namespace(namespace, name, variable):
     '''
     Add a variable to a different namespace, likely __main__.
     '''
+    import importlib
     importer_module = sys.modules[namespace]
     if name in sys.modules.keys():
-        reload(sys.modules[name])
+        importlib.reload(sys.modules[name])
     else:
-        import importlib
         m = importlib.import_module(name, None)
         sys.modules[name] = m
 
@@ -131,7 +131,7 @@ class LocalXrefs(object):
 
     def highlight(self, highlight=True, mnem=None, optype=None, direction=None,
                   text=None):
-        for (ea, info) in self.xrefs.iteritems():
+        for (ea, info) in self.xrefs.items():
             if mnem and info['mnem'] != mnem:
                 highlight = False
             elif optype and info['optype'] != optype:
@@ -162,8 +162,10 @@ def show_local_xrefs(arg=None):
     r = LocalXrefs()
     localxrefs = r
 
-    offsets = r.xrefs.keys()
-    offsets.sort()
+#    offsets = r.xrefs.keys()
+#    offsets.sort()
+
+    offsets = sorted(r.xrefs)
 
     if r.highlighted:
         ida_shims.msg(header % (r.highlighted, r.function))

--- a/plugins/mipslocalvars/mipslocalvars.py
+++ b/plugins/mipslocalvars/mipslocalvars.py
@@ -6,6 +6,7 @@
 # Craig Heffner
 # Tactical Network Solutions
 
+from __future__ import print_function
 import idaapi
 import idautils
 

--- a/plugins/mipslocalvars/mipslocalvars.py
+++ b/plugins/mipslocalvars/mipslocalvars.py
@@ -23,7 +23,7 @@ class NameMIPSSavedRegisters(object):
     }
 
     def __init__(self):
-        print "Naming saved register locations...",
+        print("Naming saved register locations...", end=' ')
 
         for ea in idautils.Functions():
             mea = ea
@@ -60,7 +60,7 @@ class NameMIPSSavedRegisters(object):
 
                 mea += self.INSIZE
 
-        print "done."
+        print("done.")
 
 
 def name_saved_registers(arg=None):

--- a/plugins/mipsrop/mipsrop.py
+++ b/plugins/mipsrop/mipsrop.py
@@ -89,11 +89,11 @@ def add_to_namespace(namespace, name, variable):
     '''
     Add a variable to a different namespace, likely __main__.
     '''
+    import importlib
     importer_module = sys.modules[namespace]
-    if name in sys.modules.keys():
-        reload(sys.modules[name])
+    if name in list(sys.modules.keys()):
+        importlib.reload(sys.modules[name])
     else:
-        import importlib
         m = importlib.import_module(name, None)
         sys.modules[name] = m
 
@@ -199,7 +199,7 @@ class BowcasterBuilder(object):
         self.gadgets = gadgets
 
     def build_code(self):
-        keys = self.gadgets.keys()
+        keys = list(self.gadgets.keys())
         keys.sort()
 
         for key in keys[::-1]:
@@ -215,7 +215,7 @@ class BowcasterBuilder(object):
 
     def print_code(self):
         for line in self.code:
-            print line
+            print(line)
 
 
 class MIPSROPFinder(object):
@@ -233,11 +233,11 @@ class MIPSROPFinder(object):
         self._initial_find()
 
         if self.controllable_jumps or self.system_calls:
-            print "MIPS ROP Finder activated, found %d controllable jumps " \
+            print("MIPS ROP Finder activated, found %d controllable jumps " \
                   "between 0x%.8X and 0x%.8X" % (len(self.controllable_jumps),
-                                                 self.start, self.end)
+                                                 self.start, self.end))
         else:
-            print "No ROP gadgets found!"
+            print("No ROP gadgets found!")
 
     def _initial_find(self):
         self.start = idc.BADADDR
@@ -519,15 +519,15 @@ class MIPSROPFinder(object):
 
     def _print_gadgets(self, gadgets):
         if gadgets:
-            print gadgets[0].header()
+            print(gadgets[0].header())
 
         for gadget in gadgets:
-            print str(gadget)
+            print(str(gadget))
 
         if gadgets:
-            print gadgets[0].footer()
+            print(gadgets[0].footer())
 
-        print "Found %d matching gadgets" % (len(gadgets))
+        print("Found %d matching gadgets" % (len(gadgets)))
 
     def _get_marked_gadgets(self):
         rop_gadgets = {}
@@ -646,15 +646,15 @@ class MIPSROPFinder(object):
             count += 1
 
         if good_gadgets:
-            for (ea, info) in good_gadgets.iteritems():
+            for (ea, info) in good_gadgets.items():
                 if info['count'] == count:
                     final_gadgets.append(info['gadget'])
                 else:
-                    print "Skipping gadget at 0x%X" % ea
+                    print("Skipping gadget at 0x%X" % ea)
         if final_gadgets:
             self._print_gadgets(gadgets)
         else:
-            print "No ROP gadgets found!"
+            print("No ROP gadgets found!")
 
     def summary(self):
         '''
@@ -680,7 +680,7 @@ class MIPSROPFinder(object):
         total_length = (3 * len(headings)) + 1
 
         if rop_gadgets:
-            gadget_keys = rop_gadgets.keys()
+            gadget_keys = list(rop_gadgets.keys())
             gadget_keys.sort()
 
             for marked_comment in gadget_keys:
@@ -709,17 +709,17 @@ class MIPSROPFinder(object):
 
                 summaries.append(summary)
 
-            for (heading, size) in lengths.iteritems():
+            for (heading, size) in lengths.items():
                 total_length += size
 
             delim = delim_char * total_length
             line_fmt = "| %%-%ds | %%-%ds | %%-%ds |" % \
                        (lengths['name'], lengths['offset'], lengths['summary'])
 
-            print delim
-            print line_fmt % \
-                  (headings['name'], headings['offset'], headings['summary'])
-            print delim
+            print(delim)
+            print(line_fmt % \
+                  (headings['name'], headings['offset'], headings['summary']))
+            print(delim)
 
             for i in range(0, len(gadget_keys)):
                 line_count = 0
@@ -734,13 +734,13 @@ class MIPSROPFinder(object):
 
                 for line in summary:
                     if line_count == 0:
-                        print line_fmt % (marked_comment, offset, line)
+                        print(line_fmt % (marked_comment, offset, line))
                     else:
-                        print line_fmt % ('', '', line)
+                        print(line_fmt % ('', '', line))
 
                     line_count += 1
 
-                print delim
+                print(delim)
 
     def build(self):
         '''
@@ -763,40 +763,40 @@ class MIPSROPFinder(object):
         '''
         delim = "-" * 140
 
-        print ""
-        print "mipsrop.find(instruction_string)"
-        print delim
-        print self.find.__doc__
+        print("")
+        print("mipsrop.find(instruction_string)")
+        print(delim)
+        print(self.find.__doc__)
 
-        print ""
-        print "mipsrop.system()"
-        print delim
-        print self.system.__doc__
+        print("")
+        print("mipsrop.system()")
+        print(delim)
+        print(self.system.__doc__)
 
-        print ""
-        print "mipsrop.doubles()"
-        print delim
-        print self.doubles.__doc__
+        print("")
+        print("mipsrop.doubles()")
+        print(delim)
+        print(self.doubles.__doc__)
 
-        print ""
-        print "mipsrop.stackfinders()"
-        print delim
-        print self.stackfinders.__doc__
+        print("")
+        print("mipsrop.stackfinders()")
+        print(delim)
+        print(self.stackfinders.__doc__)
 
-        print ""
-        print "mipsrop.tails()"
-        print delim
-        print self.tails.__doc__
+        print("")
+        print("mipsrop.tails()")
+        print(delim)
+        print(self.tails.__doc__)
 
-        print ""
-        print "mipsrop.set_base()"
-        print delim
-        print self.set_base.__doc__
+        print("")
+        print("mipsrop.set_base()")
+        print(delim)
+        print(self.set_base.__doc__)
 
-        print ""
-        print "mipsrop.summary()"
-        print delim
-        print self.summary.__doc__
+        print("")
+        print("mipsrop.summary()")
+        print(delim)
+        print(self.summary.__doc__)
 
 
 try:

--- a/plugins/mipsrop/mipsrop.py
+++ b/plugins/mipsrop/mipsrop.py
@@ -90,9 +90,14 @@ def add_to_namespace(namespace, name, variable):
     Add a variable to a different namespace, likely __main__.
     '''
     import importlib
+
     importer_module = sys.modules[namespace]
     if name in list(sys.modules.keys()):
-        importlib.reload(sys.modules[name])
+        if not (sys.version_info.major == 3 and sys.version_info.minor >= 4):
+            import imp
+            imp.reload(sys.modules[name])
+        else:
+            importlib.reload(sys.modules[name])
     else:
         m = importlib.import_module(name, None)
         sys.modules[name] = m

--- a/plugins/rizzo/rizzo.py
+++ b/plugins/rizzo/rizzo.py
@@ -26,6 +26,8 @@
 # Craig Heffner
 # @devttys0
 ##########################################################################
+
+from __future__ import print_function
 import idc
 import idaapi
 import idautils

--- a/plugins/rizzo/rizzo.py
+++ b/plugins/rizzo/rizzo.py
@@ -34,6 +34,7 @@ import os
 import time
 import pickle       # http://natashenka.ca/pickle/
 import collections
+import hashlib
 
 from shims import ida_shims
 
@@ -163,7 +164,11 @@ class Rizzo(object):
         return sigs
 
     def sighash(self, value):
-        return hash(str(value)) & 0xFFFFFFFF
+        h = hashlib.md5()
+        h.update(value.encode("utf-8"))
+        hash_value = h.hexdigest()
+        del(h)
+        return hash_value
 
     def block(self, block):
         '''
@@ -339,7 +344,6 @@ class Rizzo(object):
         formal = {}
         strings = {}
         immediates = {}
-
 
         # Match formal function signatures
         start = time.time()

--- a/plugins/rizzo/rizzo.py
+++ b/plugins/rizzo/rizzo.py
@@ -60,17 +60,17 @@ class RizzoSignatures(object):
         if not self.SHOW:
             return
 
-        print "\n\nGENERATED FORMAL SIGNATURES FOR:"
-        for (key, ea) in self.formal.iteritems():
+        print("\n\nGENERATED FORMAL SIGNATURES FOR:")
+        for (key, ea) in self.formal.items():
             func = RizzoFunctionDescriptor(self.formal, self.functions, key)
             if func.name in self.SHOW:
-                print func.name
+                print(func.name)
 
-        print "\n\nGENERATRED FUZZY SIGNATURES FOR:"
-        for (key, ea) in self.fuzzy.iteritems():
+        print("\n\nGENERATED FUZZY SIGNATURES FOR:")
+        for (key, ea) in self.fuzzy.items():
             func = RizzoFunctionDescriptor(self.fuzzy, self.functions, key)
             if func.name in self.SHOW:
-                print func.name
+                print(func.name)
 
 
 class RizzoStringDescriptor(object):
@@ -141,25 +141,25 @@ class Rizzo(object):
         self.signatures = self.generate()
         end = time.time()
 
-        print "Generated %d formal signatures and %d fuzzy signatures for %d " \
+        print("Generated %d formal signatures and %d fuzzy signatures for %d " \
               "functions in %.2f seconds." % (len(self.signatures.formal),
                                               len(self.signatures.fuzzy),
                                               len(self.signatures.functions),
-                                              (end-start))
+                                              (end-start)))
 
     def save(self):
-        print ("Saving signatures to %s..." % self.sigfile),
+        print(("Saving signatures to %s..." % self.sigfile), end=' ')
         fp = open(self.sigfile, "wb")
         pickle.dump(self.signatures, fp)
         fp.close()
-        print "done."
+        print("done.")
 
     def load(self):
-        print ("Loading signatures from %s..." % self.sigfile),
+        print(("Loading signatures from %s..." % self.sigfile), end=' ')
         fp = open(self.sigfile, "rb")
         sigs = pickle.load(fp)
         fp.close()
-        print "done."
+        print("done.")
         return sigs
 
     def sighash(self, value):
@@ -215,7 +215,7 @@ class Rizzo(object):
             # "data" to indicate that some data was referenced.
             elif drefs:
                 for dref in drefs:
-                    if self.strings.has_key(dref):
+                    if dref in self.strings:
                         formal.append(self.strings[dref].value)
                         fuzzy.append(self.strings[dref].value)
                     else:
@@ -260,7 +260,7 @@ class Rizzo(object):
         signatures = RizzoSignatures()
 
         # Generate unique string-based function signatures
-        for (ea, string) in self.strings.iteritems():
+        for (ea, string) in self.strings.items():
             # Only generate signatures on reasonably long strings with one xref
             if len(string.value) >= 8 and len(string.xrefs) == 1:
                 func = idaapi.get_func(string.xrefs[0])
@@ -297,7 +297,7 @@ class Rizzo(object):
 
                 # Check for and remove formal duplicate signatures.
                 # If no duplicates, add this to the formal signature dict.
-                if signatures.formal.has_key(formal):
+                if formal in signatures.formal:
                     del signatures.formal[formal]
                     signatures.formaldups.add(formal)
                 elif formal not in signatures.formaldups:
@@ -305,7 +305,7 @@ class Rizzo(object):
 
                 # Check for and remove fuzzy duplicate signatures.
                 # If no duplicates, add this to the fuzzy signature dict.
-                if signatures.fuzzy.has_key(fuzzy):
+                if fuzzy in signatures.fuzzy:
                     del signatures.fuzzy[fuzzy]
                     signatures.fuzzydups.add(fuzzy)
                 elif fuzzy not in signatures.fuzzydups:
@@ -315,7 +315,7 @@ class Rizzo(object):
                 # If no duplicates, add this to the immediate signature dict.
                 for (e, f, immediates, c) in blocks:
                     for immediate in immediates:
-                        if signatures.immediates.has_key(immediate):
+                        if immediate in signatures.immediates:
                             del signatures.immediates[immediate]
                             signatures.immediatedups.add(immediate)
                         elif immediate not in signatures.immediatedups:
@@ -340,9 +340,10 @@ class Rizzo(object):
         strings = {}
         immediates = {}
 
+
         # Match formal function signatures
         start = time.time()
-        for (extsig, ext_func_ea) in extsigs.formal.iteritems():
+        for (extsig, ext_func_ea) in extsigs.formal.items():
             if extsig in self.signatures.formal:
                 new_fun = RizzoFunctionDescriptor(
                     extsigs.formal, extsigs.functions, extsig)
@@ -350,12 +351,12 @@ class Rizzo(object):
                     self.signatures.formal, self.signatures.functions, extsig)
                 formal[curr_fun] = new_fun
         end = time.time()
-        print "Found %d formal matches in %.2f seconds." % (len(formal),
-                                                            (end-start))
+        print("Found %d formal matches in %.2f seconds." % (len(formal),
+                                                            (end-start)))
 
         # Match fuzzy function signatures
         start = time.time()
-        for (extsig, ext_func_ea) in extsigs.fuzzy.iteritems():
+        for (extsig, ext_func_ea) in extsigs.fuzzy.items():
             if extsig in self.signatures.fuzzy:
                 curr_fun = RizzoFunctionDescriptor(
                     self.signatures.fuzzy, self.signatures.functions, extsig)
@@ -366,12 +367,12 @@ class Rizzo(object):
                 if len(curr_fun.blocks) == len(new_fun.blocks):
                     fuzzy[curr_fun] = new_fun
         end = time.time()
-        print "Found %d fuzzy matches in %.2f seconds." % (len(fuzzy),
-                                                           (end-start))
+        print("Found %d fuzzy matches in %.2f seconds." % (len(fuzzy),
+                                                           (end-start)))
 
         # Match string based function signatures
         start = time.time()
-        for (extsig, ext_func_ea) in extsigs.strings.iteritems():
+        for (extsig, ext_func_ea) in extsigs.strings.items():
             if extsig in self.signatures.strings:
                 curr_fun = RizzoFunctionDescriptor(
                     self.signatures.strings, self.signatures.functions, extsig)
@@ -379,12 +380,12 @@ class Rizzo(object):
                     extsigs.strings, extsigs.functions, extsig)
                 strings[curr_fun] = new_fun
         end = time.time()
-        print "Found %d string matches in %.2f seconds." % (len(strings),
-                                                            (end-start))
+        print("Found %d string matches in %.2f seconds." % (len(strings),
+                                                            (end-start)))
 
         # Match immediate baesd function signatures
         start = time.time()
-        for (extsig, ext_func_ea) in extsigs.immediates.iteritems():
+        for (extsig, ext_func_ea) in extsigs.immediates.items():
             if extsig in self.signatures.immediates:
                 curr_fun = RizzoFunctionDescriptor(
                     self.signatures.immediates, self.signatures.functions,
@@ -393,8 +394,8 @@ class Rizzo(object):
                     extsigs.immediates, extsigs.functions, extsig)
                 immediates[curr_fun] = new_fun
         end = time.time()
-        print "Found %d immediate matches in %.2f seconds." % (len(immediates),
-                                                               (end-start))
+        print("Found %d immediate matches in %.2f seconds." % (len(immediates),
+                                                               (end-start)))
 
         # Return signature matches in the order we want them applied
         # The second tuple of each match is set to True if it is a fuzzy match,
@@ -431,7 +432,7 @@ class Rizzo(object):
             # functions for
             rename = {}
 
-            for (curfunc, newfunc) in match.iteritems():
+            for (curfunc, newfunc) in match.items():
                 if newfunc not in rename:
                     rename[newfunc.name] = []
 
@@ -448,50 +449,50 @@ class Rizzo(object):
                         cblock = RizzoBlockDescriptor(cblock)
 
                         if cblock.match(nblock, fuzzy):
-                            if bm.has_key(cblock):
+                            if cblock in bm:
                                 del bm[cblock]
                                 duplicates.add(cblock)
                             elif cblock not in duplicates:
                                 bm[cblock] = nblock
 
                 # Rename known function calls from each unique code block
-                for (cblock, nblock) in bm.iteritems():
+                for (cblock, nblock) in bm.items():
                     for n in range(0, len(cblock.functions)):
-                        ea = idc.LocByName(cblock.functions[n])
+                        ea = ida_shims.get_name_ea_simple(cblock.functions[n])
                         if ea != idc.BADADDR:
-                            if rename.has_key(nblock.functions[n]):
+                            if nblock.functions[n] in rename:
                                 rename[nblock.functions[n]].append(ea)
                             else:
                                 rename[nblock.functions[n]] = [ea]
 
                 # Rename the identified functions
-                for (name, candidates) in rename.iteritems():
+                for (name, candidates) in rename.items():
                     if candidates:
                         winner = \
                             collections.Counter(candidates).most_common(1)[0][0]
                         count += self.rename(winner, name)
 
         end = time.time()
-        print "Renamed %d functions in %.2f seconds." % (count, (end-start))
+        print("Renamed %d functions in %.2f seconds." % (count, (end-start)))
 
 
 def RizzoBuild(sigfile=None):
-    print "Building Rizzo signatures, this may take a few minutes..."
+    print("Building Rizzo signatures, this may take a few minutes...")
     start = time.time()
     r = Rizzo(sigfile)
     r.save()
     end = time.time()
-    print "Built signatures in %.2f seconds" % (end-start)
+    print("Built signatures in %.2f seconds" % (end-start))
 
 
 def RizzoApply(sigfile=None):
-    print "Applying Rizzo signatures, this may take a few minutes..."
+    print("Applying Rizzo signatures, this may take a few minutes...")
     start = time.time()
     r = Rizzo(sigfile)
     s = r.load()
     r.apply(s)
     end = time.time()
-    print "Signatures applied in %.2f seconds" % (end-start)
+    print("Signatures applied in %.2f seconds" % (end-start))
 
 
 def rizzo_produce(arg=None):


### PR DESCRIPTION
Ported the IDA plugins to run under Python 3. Made a few changes for backwards compatibility for Python 2 in older IDA versions.

Alleycat, codatify, fluorescence, leafblower, localxrefs, mipslocalvars, mipsrop, and rizzo were tested and validated with IDA 7.5/Py 3, IDA 7.4/Py2, IDA 7.2/Py2 (this version has no Py3 support). I wasn't sure how to test "funcprofiler". 

There were slight differences in the Rizzo and Leafblower output, but nothing that was too alarming. For example, IDA 7.5 was able to find one additional leaf function which resulted in slightly different formal/fuzzy signature results.

I plan to test IDA 7.0/Py2 and IDA 7.4/Py 3. If there any issues, I will send you a message in slack.